### PR TITLE
docs: Add description for amber-version input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -5,6 +5,7 @@ branding:
   icon: download
 inputs:
   amber-version:
+    description: The version of Amber to install.
     default: 0.4.0-alpha
   enable-cache:
     description: Whether to cache Amber binaries.


### PR DESCRIPTION
## Summary
Add missing description for the `amber-version` input parameter in action.yaml.

## Changes
- Added `description: The version of Amber to install.` to the `amber-version` input

## Reason
The `amber-version` input was missing a description field, which is inconsistent with other inputs (`enable-cache` and `cache-path`) that have descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)