### PR TITLE
fix: Add packages configuration to release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,9 @@
 {
 	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-	"release-type": "simple",
-	"include-component-in-tag": false
+	"packages": {
+		".": {
+			"release-type": "simple",
+			"include-component-in-tag": false
+		}
+	}
 }


### PR DESCRIPTION
## Summary
Fix release-please configuration by adding the missing `packages` section.

## Problem
release-please was showing "Splitting 0 commits by path" because the config file didn't define which paths/packages to manage.

## Solution
Added `packages` configuration mapping `"."` (root) to the release settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)