### PR TITLE
fix: Add SETUP_AMBER_ prefix to environment variables

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -54,9 +54,9 @@ runs:
     - name: Download Amber binary
       uses: lens0021/amber-script-action@31ab14026ac16a3d93bc20767087084ce5344517 # v1.1.1
       env:
-        AMBER_CACHE_PATH: ${{ env.amber_cache_path }}
-        AMBER_BIN_PATH: ${{ inputs.bin-path }}
-        AMBER_VERSION: ${{ inputs.amber-version }}
+        SETUP_AMBER_CACHE_PATH: ${{ env.amber_cache_path }}
+        SETUP_AMBER_BIN_PATH: ${{ inputs.bin-path }}
+        SETUP_AMBER_VERSION: ${{ inputs.amber-version }}
       with:
         amber-version: 0.5.0-alpha
         script: |
@@ -133,8 +133,8 @@ runs:
             }
           }
 
-          const cache_path = trust env_var_get("AMBER_CACHE_PATH")
-          const bin_path = trust env_var_get("AMBER_BIN_PATH")
+          const cache_path = trust env_var_get("SETUP_AMBER_CACHE_PATH")
+          const bin_path = trust env_var_get("SETUP_AMBER_BIN_PATH")
           if file_exists("{cache_path}/bin/amber") {
             $ install "{cache_path}/bin/amber" "{bin_path}" $ failed(code) {
               echo "Failed to locate binary file to {bin_path} with code {code}."
@@ -143,7 +143,7 @@ runs:
           } else {
             trust dir_create("{cache_path}/bin")
 
-            const ver = trust env_var_get("AMBER_VERSION")
+            const ver = trust env_var_get("SETUP_AMBER_VERSION")
             const os = get_os()
             const arch = get_arch()
 


### PR DESCRIPTION
## Summary

This PR adds a `SETUP_AMBER_` prefix to environment variables to prevent conflicts with amber-script-action's internal use of the same variable names.

## Problem

When amber-script-action v2.0.0 is used (PR #28), it sets its own `AMBER_VERSION` environment variable internally, which overwrites the version that setup-amber wants to install. This causes tests to fail because the wrong version gets installed.

## Solution

By using prefixed environment variable names:
- `AMBER_CACHE_PATH` → `SETUP_AMBER_CACHE_PATH`
- `AMBER_BIN_PATH` → `SETUP_AMBER_BIN_PATH`
- `AMBER_VERSION` → `SETUP_AMBER_VERSION`

We avoid this collision and ensure that setup-amber's variables are not overwritten by amber-script-action.

## Relation to other PRs

This fix is necessary for:
- PR #28 (updating to amber-script-action v2.0.0) to work correctly
- PR #25 (bumping internal amber to 0.5.1) will also benefit from this change when combined with #28

## Testing

After this change, PR #28 should pass all tests when rebased.