### PR TITLE
refactor(cache): Simplify to single file caching

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -13,7 +13,7 @@ inputs:
   cache-path:
     description: >-
       The path to directory where Amber binary caches are stored.
-      If empty string is given, the used path depends on the runner.
+      If empty string is given, defaults to ~/.tools on the runner.
     default: ""
   bin-path:
     description: >-
@@ -35,9 +35,9 @@ runs:
         if [ -n "$INPUT_CACHE_PATH" ]; then
           cache_path="$INPUT_CACHE_PATH"
         elif [ "$RUNNER_OS" == "Linux" ]; then
-          cache_path="/home/runner/.setup-amber"
+          cache_path="/home/runner/.tools"
         else
-          cache_path="/Users/runner/.setup-amber"
+          cache_path="/Users/runner/.tools"
         fi
 
         {
@@ -49,7 +49,7 @@ runs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       if: inputs.enable-cache
       with:
-        path: ${{ env.amber_cache_path }}/bin
+        path: ${{ env.amber_cache_path }}/amber
         key: setup-amber-${{ runner.os }}-${{ runner.arch }}-${{ inputs.amber-version }}
     - shell: bash
       env:

--- a/dist/main.sh
+++ b/dist/main.sh
@@ -581,11 +581,11 @@ cache_path_3="${ret_env_var_get109_v0}"
 env_var_get__109_v0 "SETUP_AMBER_BIN_PATH"
 __status=$?
 bin_path_4="${ret_env_var_get109_v0}"
-file_exists__48_v0 "${cache_path_3}/bin/amber"
+file_exists__48_v0 "${cache_path_3}/amber"
 ret_file_exists48_v0__91_4="${ret_file_exists48_v0}"
 if [ "${ret_file_exists48_v0__91_4}" != 0 ]; then
     echo "::debug::Using cached amber binary"
-    install "${cache_path_3}/bin/amber" "${bin_path_4}"
+    install "${cache_path_3}/amber" "${bin_path_4}"
     __status=$?
     if [ "${__status}" != 0 ]; then
     code_5="${__status}"
@@ -597,7 +597,7 @@ else
     __status=$?
     ver_6="${ret_env_var_get109_v0}"
     echo "::debug::Downloading amber ${ver_6}"
-    dir_create__53_v0 "${cache_path_3}/bin"
+    dir_create__53_v0 "${cache_path_3}"
     __status=$?
     get_os__164_v0 
     os_8="${ret_get_os164_v0}"
@@ -653,11 +653,11 @@ else
     # Install binary based on directory structure
     binary_source_35="$(if [ "${binary_in_subdir_16}" != 0 ]; then echo "${temp_dir_28}/${filename_15}/amber"; else echo "${temp_dir_28}/amber"; fi)"
     echo "::debug::Installing binary from ${binary_source_35}"
-    cp "${binary_source_35}" "${cache_path_3}/bin"
+    cp "${binary_source_35}" "${cache_path_3}/amber"
     __status=$?
     if [ "${__status}" != 0 ]; then
     code_36="${__status}"
-        echo "Failed to copy binary file to ${cache_path_3}/bin with code ${code_36}."
+        echo "Failed to copy binary file to ${cache_path_3}/amber with code ${code_36}."
     fi
     install "${binary_source_35}" "${bin_path_4}"
     __status=$?

--- a/src/main.ab
+++ b/src/main.ab
@@ -88,16 +88,16 @@ fun check_url_exists(url: Text): Bool {
 
 const cache_path = trust env_var_get("SETUP_AMBER_CACHE_PATH")
 const bin_path = trust env_var_get("SETUP_AMBER_BIN_PATH")
-if file_exists("{cache_path}/bin/amber") {
+if file_exists("{cache_path}/amber") {
   echo "::debug::Using cached amber binary"
-  $ install "{cache_path}/bin/amber" "{bin_path}" $ failed(code) {
+  $ install "{cache_path}/amber" "{bin_path}" $ failed(code) {
     echo "Failed to locate binary file to {bin_path} with code {code}."
     exit 1
   }
 } else {
   const ver = trust env_var_get("SETUP_AMBER_VERSION")
   echo "::debug::Downloading amber {ver}"
-  trust dir_create("{cache_path}/bin")
+  trust dir_create("{cache_path}")
 
   const os = get_os()
   const arch = get_arch()
@@ -150,8 +150,8 @@ if file_exists("{cache_path}/bin/amber") {
     else "{temp_dir}/amber"
 
   echo "::debug::Installing binary from {binary_source}"
-  $ cp "{binary_source}" "{cache_path}/bin" $ failed(code) {
-    echo "Failed to copy binary file to {cache_path}/bin with code {code}."
+  $ cp "{binary_source}" "{cache_path}/amber" $ failed(code) {
+    echo "Failed to copy binary file to {cache_path}/amber with code {code}."
   }
   $ install "{binary_source}" "{bin_path}" $ failed(code) {
     echo "Failed to install binary file to {bin_path} with code {code}."


### PR DESCRIPTION
> Cache structure has been simplified from directory-based to single file approach:
> 
> - Cache path changed from `~/.setup-amber` to `~/.tools`
> - Cache target changed from `{cache_path}/bin` (directory) to `{cache_path}/amber` (single file)
> - Version differentiation is handled by the cache key, eliminating the need for version in the filename
> 
> This makes the cache structure cleaner and more straightforward while maintaining the same functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)