### PR TITLE
feat(action): Simplify cache path initialization step

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -26,20 +26,9 @@ runs:
     - shell: bash
       env:
         INPUT_CACHE_PATH: ${{ inputs.cache-path }}
-        RUNNER_OS: ${{ runner.os }}
       run: |
-        # Export cache path
-        # using delimiter syntax to prevent injection
         delimiter="ghadelimiter_$(openssl rand -hex 16)"
-
-        if [ -n "$INPUT_CACHE_PATH" ]; then
-          cache_path="$INPUT_CACHE_PATH"
-        elif [ "$RUNNER_OS" == "Linux" ]; then
-          cache_path="/home/runner/.tools"
-        else
-          cache_path="/Users/runner/.tools"
-        fi
-
+        cache_path="${INPUT_CACHE_PATH:-$HOME/.tools}"
         {
           echo "amber_cache_path<<$delimiter"
           echo "$cache_path"


### PR DESCRIPTION
- Simplified the first step in action.yaml from 20 lines to 11 lines
- Removed unused `RUNNER_OS` environment variable
- Replaced verbose if-else logic with bash parameter expansion (`${var:-default}`)
- Unified cache path to use `$HOME/.tools` across all platforms
- Maintained security best practices (delimiter-based injection prevention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)